### PR TITLE
Add an image detection example

### DIFF
--- a/ARKit-Sampler/Assets.xcassets/AR Resources.arresourcegroup/Contents.json
+++ b/ARKit-Sampler/Assets.xcassets/AR Resources.arresourcegroup/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "resources" : [
+
+  ]
+}

--- a/ARKit-Sampler/Assets.xcassets/Contents.json
+++ b/ARKit-Sampler/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ARKit-Sampler/Samples/ARMeasure/ARMeasureViewController.swift
+++ b/ARKit-Sampler/Samples/ARMeasure/ARMeasureViewController.swift
@@ -2,9 +2,6 @@
 //  ARMeasureViewController.swift
 //  ARKit-Sampler
 //
-//  Created by Shuichi Tsutsumi on 2017/09/20.
-//  Copyright © 2017 Shuichi Tsutsumi. All rights reserved.
-//
 
 import UIKit
 import ARKit

--- a/ARKit-Sampler/Samples/ImageDetection/ImageDetection.storyboard
+++ b/ARKit-Sampler/Samples/ImageDetection/ImageDetection.storyboard
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="avV-T2-Rba">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15508"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Image Detection View Controller-->
+        <scene sceneID="crb-fS-3aJ">
+            <objects>
+                <viewController id="avV-T2-Rba" customClass="ImageDetectionViewController" customModule="ARKit_Sampler" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5or-BQ-Ufn">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <arscnView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wQ9-XE-dCc">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                            </arscnView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="wQ9-XE-dCc" firstAttribute="top" secondItem="5or-BQ-Ufn" secondAttribute="top" id="2YJ-j7-K9e"/>
+                            <constraint firstAttribute="trailing" secondItem="wQ9-XE-dCc" secondAttribute="trailing" id="RBh-uW-hUW"/>
+                            <constraint firstAttribute="bottom" secondItem="wQ9-XE-dCc" secondAttribute="bottom" id="Tbr-kJ-tBg"/>
+                            <constraint firstItem="wQ9-XE-dCc" firstAttribute="leading" secondItem="5or-BQ-Ufn" secondAttribute="leading" id="ojb-Q7-iva"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="8l0-ya-9pS"/>
+                    </view>
+                    <connections>
+                        <outlet property="sceneView" destination="wQ9-XE-dCc" id="lOl-nb-QqY"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BK9-mM-iX6" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="190" y="197"/>
+        </scene>
+    </scenes>
+</document>

--- a/ARKit-Sampler/Samples/ImageDetection/ImageDetectionViewController.swift
+++ b/ARKit-Sampler/Samples/ImageDetection/ImageDetectionViewController.swift
@@ -1,0 +1,47 @@
+//
+//  SimpleViewController.swift
+//  ARKit-Sampler
+//
+//  Created by Shuichi Tsutsumi on 2017/09/20.
+//  Copyright © 2017 Shuichi Tsutsumi. All rights reserved.
+//
+
+import UIKit
+import ARKit
+
+class ImageDetectionViewController: UIViewController {
+
+    @IBOutlet var sceneView: ARSCNView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        guard let referenceImages = ARReferenceImage.referenceImages(inGroupNamed: "AR Resources", bundle: nil) else { return }
+        
+        let configuration = ARWorldTrackingConfiguration()
+        configuration.detectionImages = referenceImages
+
+        sceneView.session.run(configuration)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        sceneView.session.pause()
+    }
+}
+
+extension ImageDetectionViewController: ARSCNViewDelegate {
+    func renderer(_ renderer: SCNSceneRenderer, didAdd node: SCNNode, for anchor: ARAnchor) {
+        guard let imageAnchor = anchor as? ARImageAnchor else { return }
+        let detectedImage = imageAnchor.referenceImage
+        
+        let box = SCNBox(width: detectedImage.physicalSize.width, height: 0.03, length: detectedImage.physicalSize.height, chamferRadius: 0)
+        let boxNode = SCNNode(geometry: box)
+        
+        node.addChildNode(boxNode)
+    }
+}


### PR DESCRIPTION
This example demonstrates how to load reference images, set up image tracking in the configuration, and place virtual content on top of images.