### PR TITLE
Modify the method of usdz load to load texture correctly

### DIFF
--- a/common/Common.swift
+++ b/common/Common.swift
@@ -84,8 +84,7 @@ extension SCNNode {
     
     func loadUsdz(name: String) {
         guard let url = Bundle.main.url(forResource: name, withExtension: "usdz") else { fatalError() }
-        let mdlAsset = MDLAsset(url: url)
-        let scene = SCNScene(mdlAsset: mdlAsset)
+        let scene = try! SCNScene(url: url, options: [.checkConsistency: true])
         for child in scene.rootNode.childNodes {
             child.geometry?.firstMaterial?.lightingModel = .physicallyBased
             addChildNode(child)


### PR DESCRIPTION
MDLAssetを用いてSCNSceneをloadするとtexture参照でエラーが発生し、色無しのモデルが表示されるのでSCNSceneに直接URLを指定するようにしました。
checkConsistencyは設定してもしなくてもtexture参照には問題ありませんでした。